### PR TITLE
ts-jest + existing tests to .ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,15 @@
 module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
   collectCoverage: true,
   collectCoverageFrom: ['**/built/cjs/*.js', '!**/node_modules/**'],
   coverageDirectory: '<rootDir>/.coverage',
   transform: {
-    '^.+\\.jsx?$': '<rootDir>/babel-jest-wrapper.js'
+    "^.+\\.(ts|tsx)$": "./node_modules/ts-jest/preprocessor.js"
   },
+  testMatch: [
+    "**/tests/**/*.test.(ts|js)"
+  ],
   setupFilesAfterEnv: ['jest-extended'],
   verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.5.4",
     "@types/d3-polygon": "^2.0.0",
     "@types/geojson": "^7946.0.7",
+    "@types/jest": "^26.0.23",
     "@types/node": "^15.3.0",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
@@ -26,6 +27,7 @@
     "npm-run-all": "^4.0.0",
     "prettier": "^2.3.0",
     "shx": "^0.3.0",
+    "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
   },
   "scripts": {

--- a/packages/math/extent/package.json
+++ b/packages/math/extent/package.json
@@ -15,10 +15,11 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config=../../../jest.config.js --roots=./packages/math/extent"
   },
   "dependencies": {
-    "@id-sdk/geo": "^3.0.0-pre.1"
+    "@id-sdk/geo": "^3.0.0-pre.1",
+    "@id-sdk/vector": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.0",

--- a/packages/math/extent/src/extent.ts
+++ b/packages/math/extent/src/extent.ts
@@ -1,8 +1,7 @@
 import { geoMetersToLat, geoMetersToLon } from '@id-sdk/geo';
+import { Vec2 } from '@id-sdk/vector'
 
-type Vec2 = [number, number];
-
-interface BBox {
+export interface BBox {
   minX: number;
   minY: number;
   maxX: number;

--- a/packages/math/extent/tests/extent.test.ts
+++ b/packages/math/extent/tests/extent.test.ts
@@ -1,4 +1,6 @@
+import 'jest-extended';
 import { Extent } from '..';
+import { Vec2 } from '@id-sdk/vector'
 
 describe('math/extent', () => {
   describe('constructor', () => {
@@ -9,23 +11,23 @@ describe('math/extent', () => {
     });
 
     it('constructs via a point', () => {
-      const p = [0, 0];
+      const p : Vec2 = [0, 0];
       const e = new Extent(p);
       expect(e.min).toStrictEqual(p);
       expect(e.max).toStrictEqual(p);
     });
 
     it('constructs via two points', () => {
-      const min = [0, 0];
-      const max = [5, 10];
+      const min : Vec2 = [0, 0];
+      const max : Vec2 = [5, 10];
       const e = new Extent(min, max);
       expect(e.min).toStrictEqual(min);
       expect(e.max).toStrictEqual(max);
     });
 
     it('constructs via an extent', () => {
-      const min = [0, 0];
-      const max = [5, 10];
+      const min : Vec2 = [0, 0];
+      const max : Vec2 = [5, 10];
       const e1 = new Extent(min, max);
       const e2 = new Extent(e1);
       expect(e2.min).toStrictEqual(min);
@@ -44,7 +46,7 @@ describe('math/extent', () => {
 
     it('accepts non-Extent argument', () => {
       const e1 = new Extent([0, 0], [10, 10]);
-      expect(e1.equals([0, 0], [10, 10])).toBeTruthy();
+      expect(e1.equals(new Extent([0, 0], [10, 10]))).toBeTruthy();
     });
   });
 
@@ -172,7 +174,7 @@ describe('math/extent', () => {
 
     it('accepts non-Extent argument', () => {
       const e1 = new Extent([0, 0], [5, 5]);
-      expect(e1.contains([1, 1], [2, 2])).toBeTrue();
+      expect(e1.contains(new Extent([1, 1], [2, 2]))).toBeTrue();
     });
   });
 
@@ -212,7 +214,7 @@ describe('math/extent', () => {
 
     it('accepts non-Extent argument', () => {
       const e1 = new Extent([0, 0], [5, 5]);
-      expect(e1.intersects([1, 1], [2, 2])).toBeTrue();
+      expect(e1.intersects(new Extent([1, 1], [2, 2]))).toBeTrue();
     });
   });
 
@@ -289,7 +291,7 @@ describe('math/extent', () => {
 
     it('accepts non-Extent argument', () => {
       const e1 = new Extent([0, 0], [2, 1]);
-      expect(e1.percentContainedIn([1, 0], [3, 1])).toBe(0.5);
+      expect(e1.percentContainedIn(new Extent([1, 0], [3, 1]))).toBe(0.5);
     });
   });
 });

--- a/packages/math/geo/package.json
+++ b/packages/math/geo/package.json
@@ -15,7 +15,10 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config ../../../jest.config.js --roots=./packages/math/geo"
+  },
+  "dependencies": {
+    "@id-sdk/vector": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.0",

--- a/packages/math/geo/src/geo.ts
+++ b/packages/math/geo/src/geo.ts
@@ -1,4 +1,4 @@
-type Vec2 = [number, number];
+import { Vec2 } from '@id-sdk/vector'
 
 // constants
 const TAU = 2 * Math.PI;
@@ -64,7 +64,7 @@ export function geoZoomToScale(z: number, tileSize?: number): number {
   return (tileSize * Math.pow(2, z)) / TAU;
 }
 
-interface Closest {
+export interface Closest {
   index: number; // index of segment along path
   distance: number; // distance from point to path
   point: Vec2; // point along path

--- a/packages/math/geo/tests/geo.test.ts
+++ b/packages/math/geo/tests/geo.test.ts
@@ -1,4 +1,6 @@
-import * as test from '..';
+import 'jest-extended';
+import * as test from '..'
+import { Vec2 } from '@id-sdk/vector'
 
 describe('math/geo', () => {
   describe('geoLatToMeters', () => {
@@ -113,28 +115,28 @@ describe('math/geo', () => {
     const CLOSE = 0; // digits
 
     it('distance between two same points is zero', () => {
-      const a = [0, 0];
-      const b = [0, 0];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [0, 0];
       expect(test.geoSphericalDistance(a, b)).toBe(0);
     });
     it('a straight 1 degree line at the equator is aproximately 111 km', () => {
-      const a = [0, 0];
-      const b = [1, 0];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [1, 0];
       expect(test.geoSphericalDistance(a, b)).toBeCloseTo(110946, CLOSE);
     });
     it('a pythagorean triangle is (nearly) right', () => {
-      const a = [0, 0];
-      const b = [4, 3];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [4, 3];
       expect(test.geoSphericalDistance(a, b)).toBeCloseTo(555282, CLOSE);
     });
     it('east-west distances at high latitude are shorter', () => {
-      const a = [0, 60];
-      const b = [1, 60];
+      const a : Vec2 = [0, 60];
+      const b : Vec2= [1, 60];
       expect(test.geoSphericalDistance(a, b)).toBeCloseTo(55473, CLOSE);
     });
     it('north-south distances at high latitude are not shorter', () => {
-      const a = [0, 60];
-      const b = [0, 61];
+      const a : Vec2 = [0, 60];
+      const b : Vec2 = [0, 61];
       expect(test.geoSphericalDistance(a, b)).toBeCloseTo(111319, CLOSE);
     });
   });
@@ -168,12 +170,12 @@ describe('math/geo', () => {
 
     it('returns closest point', () => {
       const CLOSE = 0; // digits
-      const points = [[0, 0], [1, 0], [2, 0]];
+      const points  : Vec2[] = [[0, 0], [1, 0], [2, 0]];
       const result = test.geoSphericalClosestPoint(points, [1, 1]);
       expect(result).toHaveProperty('index', 1);
       expect(result).toHaveProperty('point', [1, 0]);
       expect(result).toHaveProperty('distance');
-      expect(result.distance).toBeCloseTo(111319, CLOSE);
+      expect(result?.distance).toBeCloseTo(111319, CLOSE);
     });
   });
 });

--- a/packages/math/geom/package.json
+++ b/packages/math/geom/package.json
@@ -15,7 +15,7 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config ../../../jest.config.js --roots=./packages/math/geom"
   },
   "dependencies": {
     "@id-sdk/extent": "^3.0.0-pre.1",

--- a/packages/math/geom/src/geom.ts
+++ b/packages/math/geom/src/geom.ts
@@ -1,8 +1,6 @@
 import { polygonHull as d3_polygonHull, polygonCentroid as d3_polygonCentroid } from 'd3-polygon';
 import { Extent } from '@id-sdk/extent';
-import { vecCross, vecDot, vecEqual, vecInterp, vecLength, vecSubtract } from '@id-sdk/vector';
-
-type Vec2 = [number, number];
+import { Vec2, vecCross, vecDot, vecEqual, vecInterp, vecLength, vecSubtract } from '@id-sdk/vector';
 
 // Test whether two given coordinates describe the same edge
 export function geomEdgeEqual(a: Vec2, b: Vec2): boolean {
@@ -126,7 +124,7 @@ export function geomPolygonIntersectsPolygon(
   return testPoints(outer, inner) || (!!checkSegments && geomPathHasIntersections(outer, inner));
 }
 
-interface SSR {
+export interface SSR {
   poly: Vec2[]; // the smallest surrounding rectangle polygon
   angle: number; // angle offset from x axis
 }

--- a/packages/math/geom/tests/geom.test.ts
+++ b/packages/math/geom/tests/geom.test.ts
@@ -1,27 +1,30 @@
+import 'jest-extended';
 import * as test from '..';
+import { SSR } from '..';
+import { Vec2 } from '@id-sdk/vector';
 
 describe('math/geom', () => {
   const CLOSE = 6; // digits
 
   describe('geomEdgeEqual', () => {
     it('returns false for inequal edges', () => {
-      expect(test.geomEdgeEqual(['a', 'b'], ['a', 'c'])).toBeFalse();
+      expect(test.geomEdgeEqual(['a', 'b'] as any, ['a', 'c'] as any)).toBeFalse();
     });
 
     it('returns true for equal edges along same direction', () => {
-      expect(test.geomEdgeEqual(['a', 'b'], ['a', 'b'])).toBeTrue();
+      expect(test.geomEdgeEqual(['a', 'b'] as any, ['a', 'b'] as any)).toBeTrue();
     });
 
     it('returns true for equal edges along opposite direction', () => {
-      expect(test.geomEdgeEqual(['a', 'b'], ['b', 'a'])).toBeTrue();
+      expect(test.geomEdgeEqual(['a', 'b'] as any, ['b', 'a'] as any)).toBeTrue();
     });
   });
 
   describe('geomRotatePoints', () => {
     it('rotates points around [0, 0]', () => {
-      const points = [[5, 0], [5, 1]];
+      const points : Vec2[] = [[5, 0], [5, 1]];
       const angle = Math.PI;
-      const around = [0, 0];
+      const around : Vec2 = [0, 0];
       const result = test.geomRotatePoints(points, angle, around);
       expect(result[0][0]).toBeCloseTo(-5, CLOSE);
       expect(result[0][1]).toBeCloseTo(0, CLOSE);
@@ -30,9 +33,9 @@ describe('math/geom', () => {
     });
 
     it('rotates points around [3, 0]', () => {
-      const points = [[5, 0], [5, 1]];
+      const points : Vec2[] = [[5, 0], [5, 1]];
       const angle = Math.PI;
-      const around = [3, 0];
+      const around : Vec2 = [3, 0];
       const result = test.geomRotatePoints(points, angle, around);
       expect(result[0][0]).toBeCloseTo(1, CLOSE);
       expect(result[0][1]).toBeCloseTo(0, CLOSE);
@@ -43,8 +46,8 @@ describe('math/geom', () => {
 
   describe('geomLineIntersection', () => {
     it('returns null if either line is not a proper line segment', () => {
-      const a = [[0, 0], [10, 0]];
-      const b = [[-5, 0], [5, 0]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[-5, 0], [5, 0]];
       expect(test.geomLineIntersection([], b)).toBeNull();
       expect(test.geomLineIntersection([[0, 0]], b)).toBeNull();
       expect(test.geomLineIntersection(a, [])).toBeNull();
@@ -55,8 +58,8 @@ describe('math/geom', () => {
       //
       //   b0 --- a0 === b1 --- a1
       //
-      const a = [[0, 0], [10, 0]];
-      const b = [[-5, 0], [5, 0]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[-5, 0], [5, 0]];
       expect(test.geomLineIntersection(a, b)).toBeNull();
     });
 
@@ -64,8 +67,8 @@ describe('math/geom', () => {
       //
       //   b0 --- b1     a0 --- a1
       //
-      const a = [[5, 0], [10, 0]];
-      const b = [[-10, 0], [-5, 0]];
+      const a : Vec2[] = [[5, 0], [10, 0]];
+      const b : Vec2[] = [[-10, 0], [-5, 0]];
       expect(test.geomLineIntersection(a, b)).toBeNull();
     });
 
@@ -73,8 +76,8 @@ describe('math/geom', () => {
       //   b0 ------- b1
       //
       //   a0 ------- a1
-      const a = [[0, 0], [10, 0]];
-      const b = [[0, 5], [10, 5]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[0, 5], [10, 5]];
       expect(test.geomLineIntersection(a, b)).toBeNull();
     });
 
@@ -84,21 +87,21 @@ describe('math/geom', () => {
       //   a0 ---*--- a1
       //         |
       //         b1
-      const a = [[0, 0], [10, 0]];
-      const b = [[5, 10], [5, -10]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[5, 10], [5, -10]];
       expect(test.geomLineIntersection(a, b)).toStrictEqual([5, 0]);
     });
     it('returns null if lines are not parallel but not intersecting', () => {
-      const a = [[0, 0], [10, 0]];
-      const b = [[-5, 10], [-5, -10]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[-5, 10], [-5, -10]];
       expect(test.geomLineIntersection(a, b)).toBeNull();
     });
   });
 
   describe('geomPathIntersections', () => {
     it('returns empty array if either path is not at least a proper line segment', () => {
-      const a = [[0, 0], [10, 0]];
-      const b = [[5, 5], [5, -5], [10, -5], [5, 5]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[5, 5], [5, -5], [10, -5], [5, 5]];
       expect(test.geomPathIntersections([], b)).toHaveLength(0);
       expect(test.geomPathIntersections([[0, 0]], b)).toHaveLength(0);
       expect(test.geomPathIntersections(a, [])).toHaveLength(0);
@@ -111,16 +114,16 @@ describe('math/geom', () => {
       //   a0 ---*--*--- a1
       //         |   \
       //        b1 -- b2
-      const a = [[0, 0], [10, 0]];
-      const b = [[5, 5], [5, -5], [10, -5], [5, 5]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[5, 5], [5, -5], [10, -5], [5, 5]];
       expect(test.geomPathIntersections(a, b)).toStrictEqual([[5, 0], [7.5, 0]]);
     });
   });
 
   describe('geomPathHasIntersections', () => {
     it('returns false if either path is not at least a proper line segment', () => {
-      const a = [[0, 0], [10, 0]];
-      const b = [[5, 5], [5, -5], [10, -5], [5, 5]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[5, 5], [5, -5], [10, -5], [5, 5]];
       expect(test.geomPathHasIntersections([], b)).toBeFalse();
       expect(test.geomPathHasIntersections([[0, 0]], b)).toBeFalse();
       expect(test.geomPathHasIntersections(a, [])).toBeFalse();
@@ -133,8 +136,8 @@ describe('math/geom', () => {
       //   a0 ---*--*--- a1
       //         |   \
       //        b1 -- b2
-      const a = [[0, 0], [10, 0]];
-      const b = [[5, 5], [5, -5], [10, -5], [5, 5]];
+      const a : Vec2[] = [[0, 0], [10, 0]];
+      const b : Vec2[] = [[5, 5], [5, -5], [10, -5], [5, 5]];
       expect(test.geomPathHasIntersections(a, b)).toBeTrue();
     });
   });
@@ -144,8 +147,8 @@ describe('math/geom', () => {
       //   p1 --- p2
       //   |   *   |
       //   p0 --- p3
-      const poly = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
-      const point = [0.5, 0.5];
+      const poly : Vec2[] = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
+      const point : Vec2 = [0.5, 0.5];
       expect(test.geomPointInPolygon(point, poly)).toBeTrue();
     });
     it('says a point outside of a polygon is outside', () => {
@@ -153,8 +156,8 @@ describe('math/geom', () => {
       //   p1 --- p2
       //   |       |
       //   p0 --- p3
-      const poly = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
-      const point = [0.5, 1.5];
+      const poly : Vec2[] = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
+      const point : Vec2 = [0.5, 1.5];
       expect(test.geomPointInPolygon(point, poly)).toBeFalse();
     });
   });
@@ -166,8 +169,8 @@ describe('math/geom', () => {
       //   |  |      |  |
       //   |  i0 -- i3  |
       //   o0 -------- o3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
       expect(test.geomPolygonContainsPolygon(outer, inner)).toBeTrue();
     });
     it('says a polygon outside of a polygon is out', () => {
@@ -178,8 +181,8 @@ describe('math/geom', () => {
       //   |  |      |  |
       //   |  i0 -- i3  |
       //   o0 -------- o3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, 1], [1, 9], [2, 2], [2, 1], [1, 1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, 1], [1, 9], [2, 2], [2, 1], [1, 1]];
       expect(test.geomPolygonContainsPolygon(outer, inner)).toBeFalse();
     });
   });
@@ -191,8 +194,8 @@ describe('math/geom', () => {
       //   |  |      |  |
       //   |  i0 -- i3  |
       //   o0 -------- o3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner)).toBeTrue();
     });
 
@@ -202,8 +205,8 @@ describe('math/geom', () => {
       //   |  |      |  |
       //   |  o0 -- o3  |
       //   i0 -------- i3
-      const inner = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const outer = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
+      const inner : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const outer : Vec2[] = [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner)).toBeFalse();
     });
 
@@ -215,8 +218,8 @@ describe('math/geom', () => {
       //   |  |      |  |
       //   |  i0 -- i3  |
       //   o0 -------- o3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, 1], [1, 9], [2, 2], [2, 1], [1, 1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, 1], [1, 9], [2, 2], [2, 1], [1, 1]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner)).toBeTrue();
     });
 
@@ -227,8 +230,8 @@ describe('math/geom', () => {
       //   |   |      |   |
       //   o0 -+------+-- o3
       //       i0 -- i3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, -1], [1, 4], [2, 4], [2, -1], [1, -1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, -1], [1, 4], [2, 4], [2, -1], [1, -1]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner)).toBeFalse();
     });
 
@@ -239,8 +242,8 @@ describe('math/geom', () => {
       //   |   |      |   |
       //   o0 -+------+-- o3
       //       i0 -- i3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[1, -1], [1, 4], [2, 4], [2, -1], [1, -1]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[1, -1], [1, 4], [2, 4], [2, -1], [1, -1]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner, true)).toBeTrue();
     });
 
@@ -249,8 +252,8 @@ describe('math/geom', () => {
       //   |        |    |        |
       //   |        |    |        |
       //   o0 ---- o3    i0 ---- i3
-      const outer = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
-      const inner = [[5, 0], [5, 3], [8, 3], [8, 0], [5, 0]];
+      const outer : Vec2[] = [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]];
+      const inner : Vec2[] = [[5, 0], [5, 3], [8, 3], [8, 0], [5, 0]];
       expect(test.geomPolygonIntersectsPolygon(outer, inner)).toBeFalse();
     });
   });
@@ -264,8 +267,8 @@ describe('math/geom', () => {
       //  +-- p1 ------ p3
       //  |              |
       //  p0 ------ p2 --+
-      const points = [[0, -1], [5, 1], [10, -1], [15, 1]];
-      const ssr = test.geomGetSmallestSurroundingRectangle(points);
+      const points : Vec2[] = [[0, -1], [5, 1], [10, -1], [15, 1]];
+      const ssr : SSR = test.geomGetSmallestSurroundingRectangle(points) as SSR;
       expect(ssr.poly).toStrictEqual([[0, -1], [0, 1], [15, 1], [15, -1], [0, -1]]);
       expect(ssr.angle).toBe(0);
     });
@@ -273,23 +276,23 @@ describe('math/geom', () => {
 
   describe('geomPathLength', () => {
     it('calculates a simple path length', () => {
-      const path = [[0, 0], [0, 1], [3, 5]];
+      const path : Vec2[] = [[0, 0], [0, 1], [3, 5]];
       expect(test.geomPathLength(path)).toBe(6);
     });
 
     it('does not fail on single-point path', () => {
-      const path = [[0, 0]];
+      const path : Vec2[] = [[0, 0]];
       expect(test.geomPathLength(path)).toBe(0);
     });
 
     it('estimates zero-length edges', () => {
-      const path = [[0, 0], [0, 0]];
+      const path : Vec2[] = [[0, 0], [0, 0]];
       expect(test.geomPathLength(path)).toBe(0);
     });
   });
 
   describe('geomViewportNudge', () => {
-    const dimensions = [1000, 1000];
+    const dimensions : Vec2 = [1000, 1000];
     it('returns null if the point is not at the edge', () => {
       expect(test.geomViewportNudge([500, 500], dimensions)).toBeNull();
     });

--- a/packages/math/projection/package.json
+++ b/packages/math/projection/package.json
@@ -15,11 +15,12 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config ../../../jest.config.js --roots=./packages/math/projection"
   },
   "dependencies": {
     "d3-geo": "^2.0.1",
-    "d3-zoom": "^2.0.0"
+    "d3-zoom": "^2.0.0",
+    "@id-sdk/vector": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.0",

--- a/packages/math/projection/src/projection.ts
+++ b/packages/math/projection/src/projection.ts
@@ -1,9 +1,8 @@
 import { geoMercatorRaw as d3_geoMercatorRaw, geoTransform as d3_geoTransform } from 'd3-geo';
 import { zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
+import { Vec2 } from '@id-sdk/vector'
 
-type Vec2 = [number, number];
-
-interface Transform {
+export interface Transform {
   x: number;
   y: number;
   k: number;

--- a/packages/math/projection/tests/projection.test.ts
+++ b/packages/math/projection/tests/projection.test.ts
@@ -1,4 +1,5 @@
-import { Projection } from '..';
+import { Projection, Transform } from '..';
+import { Vec2 } from '@id-sdk/vector'
 
 describe('math/projection', () => {
   const CLOSE = 6; // digits
@@ -6,7 +7,7 @@ describe('math/projection', () => {
   describe('constructor', () => {
     it('creates a default Projection', () => {
       const proj = new Projection();
-      const t = proj.transform();
+      const t : Transform = proj.transform() as Transform;
       expect(t.x).toBe(0);
       expect(t.y).toBe(0);
       expect(t.k).toBe(256 / Math.PI); // z1
@@ -14,7 +15,7 @@ describe('math/projection', () => {
 
     it('creates a Projection with parameters', () => {
       const proj = new Projection(20, 30, 512 / Math.PI);
-      const t = proj.transform();
+      const t : Transform = proj.transform() as Transform;
       expect(t.x).toBe(20);
       expect(t.y).toBe(30);
       expect(t.k).toBe(512 / Math.PI); // z2
@@ -207,21 +208,21 @@ describe('math/projection', () => {
 
   describe('#scale', () => {
     it('sets/gets scale', () => {
-      const proj = new Projection().scale(512 / Math.PI);
+      const proj : Projection = new Projection().scale(512 / Math.PI) as Projection;
       expect(proj.scale()).toBe(512 / Math.PI);
     });
   });
 
   describe('#translate', () => {
     it('sets/gets translate', () => {
-      const proj = new Projection().translate([20, 30]);
+      const proj : Projection = new Projection().translate([20, 30]) as Projection;
       expect(proj.translate()).toStrictEqual([20, 30]);
     });
   });
 
   describe('#dimensions', () => {
     it('sets/gets dimensions', () => {
-      const proj = new Projection().dimensions([[0, 0], [800, 600]]);
+      const proj : Projection = new Projection().dimensions([[0, 0], [800, 600]]) as Projection;
       expect(proj.dimensions()).toStrictEqual([[0, 0], [800, 600]]);
     });
   });
@@ -229,7 +230,7 @@ describe('math/projection', () => {
   describe('#transform', () => {
     it('sets/gets transform', () => {
       const t = { x: 20, y: 30, k: 512 / Math.PI };
-      const proj = new Projection().transform(t);
+      const proj : Projection = new Projection().transform(t) as Projection;
       expect(proj.transform()).toMatchObject(t);
     });
   });

--- a/packages/math/tiler/package.json
+++ b/packages/math/tiler/package.json
@@ -15,12 +15,13 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config ../../../jest.config.js --roots=./packages/math/tiler"
   },
   "dependencies": {
     "@id-sdk/extent": "^3.0.0-pre.1",
     "@id-sdk/geo": "^3.0.0-pre.1",
-    "@id-sdk/projection": "^3.0.0-pre.1"
+    "@id-sdk/projection": "^3.0.0-pre.1",
+    "@id-sdk/vector": "^3.0.0-pre.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.0",

--- a/packages/math/tiler/src/tiler.ts
+++ b/packages/math/tiler/src/tiler.ts
@@ -1,11 +1,11 @@
 import { Extent } from '@id-sdk/extent';
 import { Projection } from '@id-sdk/projection';
 import { geoScaleToZoom } from '@id-sdk/geo';
+import { Vec2 } from '@id-sdk/vector'
 
-type Vec2 = [number, number];
-type TileCoord = [number, number, number];
+export type TileCoord = [number, number, number];
 
-interface Tile {
+export interface Tile {
   id: string; // tile identifier string ex. '0,0,0'
   xyz: TileCoord; // tile coordinate array ex. [0,0,0]
   pxExtent: Extent; // pixel x/y coordinate extent
@@ -13,7 +13,7 @@ interface Tile {
   isVisible: boolean; // true if the tile is visible, false if not
 }
 
-interface TileResult {
+export interface TileResult {
   tiles: Tile[];
   // translate: Vec2;
   // scale: number;

--- a/packages/math/tiler/tests/tiler.test.ts
+++ b/packages/math/tiler/tests/tiler.test.ts
@@ -1,3 +1,4 @@
+import 'jest-extended';
 import { Tiler } from '..';
 import { Projection } from '@id-sdk/projection';
 
@@ -29,8 +30,8 @@ describe('math/tiler', () => {
           //-180    +180
           //
           const k = (TS * Math.pow(2, 0)) / TAU; // z0
-          const t = new Tiler().tileSize(TS);
-          const p = new Projection(HALFTS, HALFTS, k).dimensions([[0, 0], [TS, TS]]); // entire world visible
+          const t : Tiler = new Tiler().tileSize(TS) as Tiler;
+          const p : Projection = new Projection(HALFTS, HALFTS, k).dimensions([[0, 0], [TS, TS]]) as Projection; // entire world visible
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -82,8 +83,8 @@ describe('math/tiler', () => {
           //-180      0     +180
           //
           const k = (TS * Math.pow(2, 1)) / TAU; // z1
-          const t = new Tiler().tileSize(TS);
-          const p = new Projection(TS, TS, k).dimensions([[0, 0], [TWOTS, TWOTS]]); // entire world visible
+          const t : Tiler = new Tiler().tileSize(TS) as Tiler;
+          const p : Projection = new Projection(TS, TS, k).dimensions([[0, 0], [TWOTS, TWOTS]]) as Projection; // entire world visible
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -165,8 +166,8 @@ describe('math/tiler', () => {
           //-180     -90      0      +90    +180
           //
           const k = (TS * Math.pow(2, 2)) / TAU; // z2
-          const t = new Tiler().tileSize(TS);
-          const p = new Projection(TWOTS, TWOTS, k).dimensions([[0, 0], [FOURTS, FOURTS]]); // entire world visible
+          const t : Tiler = new Tiler().tileSize(TS) as Tiler;
+          const p = new Projection(TWOTS, TWOTS, k).dimensions([[0, 0], [FOURTS, FOURTS]]) as Projection; // entire world visible
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -247,8 +248,8 @@ describe('math/tiler', () => {
           // |       |       |       |       |
           // +-------+-------+-------+-------+
           const k = (TS * Math.pow(2, 2)) / TAU; // z2
-          const t = new Tiler().tileSize(TS);
-          const p = new Projection(HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]);
+          const t : Tiler = new Tiler().tileSize(TS) as Tiler;
+          const p = new Projection(HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]) as Projection;
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -286,8 +287,8 @@ describe('math/tiler', () => {
           // |       |       |       |       |
           // +-------+-------+-------+-------+
           const k = (TS * Math.pow(2, 2)) / TAU; // z2
-          const t = new Tiler().tileSize(TS).margin(1);
-          const p = new Projection(HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]);
+          const t : Tiler = (new Tiler().tileSize(TS) as Tiler).margin(1) as Tiler;
+          const p = new Projection(HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]) as Projection;
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -338,9 +339,9 @@ describe('math/tiler', () => {
           // | 0,3,2 | 1,3,2 | 2,3,2 | 3,3,2 |
           // |       |       |       |       |
           // +-------+-------+-------+-------+
-          const k = (TS * Math.pow(2, 2)) / TAU; // z2
-          const t = new Tiler().tileSize(TS);
-          const p = new Projection(0, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]);
+          const k = (TS * Math.pow(2, 2)) / TAU; // z2 
+          const t = new Tiler().tileSize(TS) as Tiler;
+          const p = new Projection(0, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]) as Projection;
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -378,8 +379,8 @@ describe('math/tiler', () => {
           // |       |       |       |       |
           // +-------+-------+-------+-------+
           const k = (TS * Math.pow(2, 2)) / TAU; // z2
-          const t = new Tiler().tileSize(TS).margin(1);
-          const p = new Projection(0, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]);
+          const t = (new Tiler().tileSize(TS) as Tiler).margin(1) as Tiler;
+          const p = new Projection(0, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]) as Projection;
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -431,11 +432,11 @@ describe('math/tiler', () => {
           // |         |         |         |         |
           // +---------+---------+---------+---------+
           const k = (TS * Math.pow(2, 7)) / TAU; // z7
-          const t = new Tiler()
-            .tileSize(TS)
-            .margin(1)
-            .skipNullIsland(true);
-          const p = new Projection(-HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]);
+          const t = ((new Tiler()
+            .tileSize(TS) as Tiler)
+            .margin(1) as Tiler)
+            .skipNullIsland(true) as Tiler;
+          const p = new Projection(-HALFTS, HALFTS, k).dimensions([[1, 1], [TS - 1, TS - 1]]) as Projection;
 
           const result = t.getTiles(p);
           const tiles = result.tiles;
@@ -471,8 +472,8 @@ describe('math/tiler', () => {
         describe('getGeoJSON', () => {
           it('gets GeoJSON', () => {
             const k = (TS * Math.pow(2, 0)) / TAU; // z0
-            const t = new Tiler().tileSize(TS);
-            const p = new Projection(HALFTS, HALFTS, k).dimensions([[0, 0], [TS, TS]]);
+            const t = new Tiler().tileSize(TS) as Tiler;
+            const p = new Projection(HALFTS, HALFTS, k).dimensions([[0, 0], [TS, TS]]) as Projection;
 
             const result = t.getTiles(p);
             const gj = t.getGeoJSON(result);
@@ -557,28 +558,28 @@ describe('math/tiler', () => {
 
   describe('#tileSize', () => {
     it('sets/gets tileSize', () => {
-      const t = new Tiler().tileSize(512);
+      const t = new Tiler().tileSize(512) as Tiler;
       expect(t.tileSize()).toBe(512);
     });
   });
 
   describe('#zoomRange', () => {
     it('sets/gets zoomRange', () => {
-      const t = new Tiler().zoomRange([10, 20]);
+      const t = new Tiler().zoomRange([10, 20]) as Tiler;
       expect(t.zoomRange()).toStrictEqual([10, 20]);
     });
   });
 
   describe('#margin', () => {
     it('sets/gets margin', () => {
-      const t = new Tiler().margin(1);
+      const t = new Tiler().margin(1) as Tiler;
       expect(t.margin()).toBe(1);
     });
   });
 
   describe('#skipNullIsland', () => {
     it('sets/gets skipNullIsland', () => {
-      const t = new Tiler().skipNullIsland(true);
+      const t = new Tiler().skipNullIsland(true) as Tiler;
       expect(t.skipNullIsland()).toBeTrue();
     });
   });

--- a/packages/math/vector/package.json
+++ b/packages/math/vector/package.json
@@ -15,7 +15,7 @@
     "build": "npm-run-all -s build:**",
     "build:es6": "tsc --project ./tsconfig.es6.json",
     "build:cjs": "tsc --project ./tsconfig.cjs.json",
-    "test": "jest --config ../../../jest.config.js tests/*.js"
+    "test": "jest --config ../../../jest.config.js --roots=./packages/math/vector"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.0",

--- a/packages/math/vector/src/vector.ts
+++ b/packages/math/vector/src/vector.ts
@@ -1,4 +1,4 @@
-type Vec2 = [number, number];
+export type Vec2 = [number, number];
 
 // Test whether two given vectors are equal (optionally, to within epsilon)
 export function vecEqual(a: Vec2, b: Vec2, epsilon?: number): boolean {
@@ -84,7 +84,7 @@ export function vecCross(a: Vec2, b: Vec2, origin?: Vec2): number {
   return p[0] * q[1] - p[1] * q[0];
 }
 
-interface Edge {
+export interface Edge {
   index: number; // index of segment along path
   distance: number; // distance from point to path
   target: Vec2; // point along path

--- a/packages/math/vector/tests/vector.test.ts
+++ b/packages/math/vector/tests/vector.test.ts
@@ -1,4 +1,6 @@
 import * as test from '..';
+import { Vec2, Edge } from '..';
+
 const CLOSE = 6; // digits
 
 describe('math/vector', () => {
@@ -49,31 +51,31 @@ describe('math/vector', () => {
 
   describe('vecInterp', () => {
     it('interpolates halfway', () => {
-      const a = [0, 0];
-      const b = [10, 10];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [10, 10];
       expect(test.vecInterp(a, b, 0.5)).toEqual([5, 5]);
     });
     it('interpolates to one side', () => {
-      const a = [0, 0];
-      const b = [10, 10];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [10, 10];
       expect(test.vecInterp(a, b, 0)).toEqual([0, 0]);
     });
   });
 
   describe('vecLength', () => {
     it('distance between two same points is zero', () => {
-      const a = [0, 0];
-      const b = [0, 0];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [0, 0];
       expect(test.vecLength(a, b)).toEqual(0);
     });
     it('a straight 10 unit line is 10', () => {
-      const a = [0, 0];
-      const b = [10, 0];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [10, 0];
       expect(test.vecLength(a, b)).toEqual(10);
     });
     it('a pythagorean triangle is right', () => {
-      const a = [0, 0];
-      const b = [4, 3];
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [4, 3];
       expect(test.vecLength(a, b)).toEqual(5);
     });
     it('defaults second argument to [0,0]', () => {
@@ -103,49 +105,49 @@ describe('math/vector', () => {
 
   describe('vecDot', () => {
     it('dot product of right angle is zero', () => {
-      const a = [1, 0];
-      const b = [0, 1];
+      const a : Vec2 = [1, 0];
+      const b : Vec2 = [0, 1];
       expect(test.vecDot(a, b)).toEqual(0);
     });
     it('dot product of same vector multiplies', () => {
-      const a = [2, 0];
-      const b = [2, 0];
+      const a : Vec2 = [2, 0];
+      const b : Vec2 = [2, 0];
       expect(test.vecDot(a, b)).toEqual(4);
     });
   });
 
   describe('vecNormalizedDot', () => {
     it('normalized dot product of right angle is zero', () => {
-      const a = [2, 0];
-      const b = [0, 2];
+      const a : Vec2 = [2, 0];
+      const b : Vec2 = [0, 2];
       expect(test.vecNormalizedDot(a, b)).toEqual(0);
     });
     it('normalized dot product of same vector multiplies unit vectors', () => {
-      const a = [2, 0];
-      const b = [2, 0];
+      const a : Vec2 = [2, 0];
+      const b : Vec2 = [2, 0];
       expect(test.vecNormalizedDot(a, b)).toEqual(1);
     });
     it('normalized dot product of 45 degrees', () => {
-      const a = [0, 2];
-      const b = [2, 2];
+      const a : Vec2 = [0, 2];
+      const b : Vec2 = [2, 2];
       expect(test.vecNormalizedDot(a, b)).toBeCloseTo(Math.sqrt(2) / 2, CLOSE);
     });
   });
 
   describe('vecCross', () => {
     it('2D cross product of right hand turn is positive', () => {
-      const a = [2, 0];
-      const b = [0, 2];
+      const a : Vec2 = [2, 0];
+      const b : Vec2 = [0, 2];
       expect(test.vecCross(a, b)).toEqual(4);
     });
     it('2D cross product of left hand turn is negative', () => {
-      const a = [2, 0];
-      const b = [0, -2];
+      const a : Vec2 = [2, 0];
+      const b : Vec2 = [0, -2];
       expect(test.vecCross(a, b)).toEqual(-4);
     });
     it('2D cross product of colinear points is zero', () => {
-      const a = [-2, 0];
-      const b = [2, 0];
+      const a : Vec2 = [-2, 0];
+      const b : Vec2 = [2, 0];
       expect(test.vecCross(a, b)).toBe(-0);
     });
   });
@@ -156,7 +158,7 @@ describe('math/vector', () => {
     });
 
     it('returns null for a degenerate path (single node)', () => {
-      expect(test.vecProject([0, 1], [0, 0])).toBeNull();
+      expect(test.vecProject([0, 1], [0, 0] as any)).toBeNull();
     });
 
     it('calculates the orthogonal projection of a point onto a path', () => {
@@ -165,30 +167,30 @@ describe('math/vector', () => {
       // a --*--- b
       //
       // * = [2, 0]
-      const a = [0, 0];
-      const b = [5, 0];
-      const c = [2, 1];
-      const edge = test.vecProject(c, [a, b]);
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [5, 0];
+      const c : Vec2 = [2, 1];
+      const edge : Edge = test.vecProject(c, [a, b]) as Edge;
       expect(edge.index).toEqual(1);
       expect(edge.distance).toEqual(1);
       expect(edge.target).toEqual([2, 0]);
     });
 
     it('returns the starting vertex when the orthogonal projection is < 0', () => {
-      const a = [0, 0];
-      const b = [5, 0];
-      const c = [-3, 4];
-      const edge = test.vecProject(c, [a, b]);
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [5, 0];
+      const c : Vec2 = [-3, 4];
+      const edge : Edge = test.vecProject(c, [a, b]) as Edge;
       expect(edge.index).toEqual(1);
       expect(edge.distance).toEqual(5);
       expect(edge.target).toEqual([0, 0]);
     });
 
     it('returns the ending vertex when the orthogonal projection is > 1', () => {
-      const a = [0, 0];
-      const b = [5, 0];
-      const c = [8, 4];
-      const edge = test.vecProject(c, [a, b]);
+      const a : Vec2 = [0, 0];
+      const b : Vec2 = [5, 0];
+      const c : Vec2 = [8, 4];
+      const edge : Edge = test.vecProject(c, [a, b]) as Edge;
       expect(edge.index).toEqual(1);
       expect(edge.distance).toEqual(5);
       expect(edge.target).toEqual([5, 0]);


### PR DESCRIPTION
Testing infrastructure changes: (#40 addressed) 
- Added [ts-jest](https://www.npmjs.com/package/ts-jest) 
- package/math tests ported .js -> .ts (some strong typing changes included)


Jest individual package testing config fixed by providing root cli parameter
1. This works fine now with the exception for coverage which includes not only the package of interest, but it can also include dependent packages, not sure how to handle this one. Asking reviewers to provide input on this.
2. Root solution would require providing root param for each package in package.json, can we automate this long term?

Package/math small code change:
- Vec2 from vector as export and import to other math packages.
