### PR TITLE
Build - Yarn as bootstrap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npx lerna bootstrap --no-ci
-    - run: npm run all
-    - run: npm run test
+    - run: yarn
+    - run: yarn run all
+    - run: yarn run test


### PR DESCRIPTION
Modified build pipeline to use yarn instead of lerna bootstrap + npm install.
(Also set yarn as prefix for commands for consistency reasons).

(edit): Notice the install/bootstrap perf (e.g. on node16):
[now ](https://github.com/ideditor/id-sdk/pull/46/checks?check_run_id=2683642140)(**28s**)
Run yarn - 28s
[was](https://github.com/ideditor/id-sdk/runs/2678142119?check_suite_focus=true): (**67s**)
Run npm run install - 40s
Run npx lerna bootstrap --no-ci - 27s