### PR TITLE
Add one missing method for vecLengthSquared.

### DIFF
--- a/packages/math/packages/vector/src/vector.ts
+++ b/packages/math/packages/vector/src/vector.ts
@@ -44,6 +44,11 @@ export function vecLength(a: Vec2, b?: Vec2): number {
   return Math.sqrt(x * x + y * y);
 }
 
+// length of vector raised to the power two
+export function vecLengthSquare(a: Vec2, b: Vec2 = [0, 0]) {
+  return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2;
+}
+
 // Normalize a vector (return a unit vector)
 export function vecNormalize(a: Vec2): Vec2 {
   const length: number = Math.sqrt(a[0] * a[0] + a[1] * a[1]);

--- a/packages/math/packages/vector/tests/vector.test.ts
+++ b/packages/math/packages/vector/tests/vector.test.ts
@@ -83,6 +83,27 @@ describe('math/vector', () => {
     });
   });
 
+  describe('vecLengthSquare', () => {
+    it('distance between two same points is zero', () => {
+      const a: Vec2 = [0, 0];
+      const b: Vec2 = [0, 0];
+      expect(test.vecLengthSquare(a, b)).toEqual(0);
+    });
+    it('a straight 10 unit line is 10', () => {
+      const a: Vec2 = [0, 0];
+      const b: Vec2 = [10, 0];
+      expect(test.vecLengthSquare(a, b)).toEqual(100);
+    });
+    it('a pythagorean triangle is right', () => {
+      const a: Vec2 = [0, 0];
+      const b: Vec2 = [4, 3];
+      expect(test.vecLengthSquare(a, b)).toEqual(25);
+    });
+    it('defaults second argument to [0,0]', () => {
+      expect(test.vecLengthSquare([4, 3])).toEqual(25);
+    });
+  });
+
   describe('vecNormalize', () => {
     it('gets unit vectors', () => {
       expect(test.vecNormalize([0, 0])).toEqual([0, 0]);


### PR DESCRIPTION
Very simple, we were just missing one method to support all of iD/RapiD's use cases. 

Cloned the existing `vecLength` tests and just squared the expected result. 