### PR TITLE
add method "utilSortString" to sort strings alphabetically

### DIFF
--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -33,3 +33,4 @@ export { utilUnicodeCharsCount } from './string';
 export { utilUnicodeCharsTruncated } from './string';
 export { utilSafeString } from './string';
 export { utilUniqueString } from './string';
+export { utilSortString } from './string';

--- a/packages/util/src/string.ts
+++ b/packages/util/src/string.ts
@@ -109,3 +109,22 @@ export function utilSafeString(str) {
 export function utilUniqueString(val) {
   return 'ideditor-' + utilSafeString(val.toString()) + '-' + new Date().getTime().toString();
 }
+
+// Returns a comparator function for sorting strings alphabetically in ascending order,
+// regardless of case or diacritics.
+// If supported, will use the browser's language sensitive string comparison, see:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator
+export function utilSortString(locale: string): (x: string, y: string) => number {
+  if ('Intl' in window && 'Collator' in Intl) {
+      return (new Intl.Collator(locale || 'en', {
+          sensitivity: 'base',
+          numeric: true
+      })).compare;
+  } else {
+      return (a, b) => {
+          a = removeDiacritics(a.toLowerCase());
+          b = removeDiacritics(b.toLowerCase());
+          return a < b ? -1 : a > b ? 1 : 0;
+      };
+  }
+}

--- a/packages/util/src/string.ts
+++ b/packages/util/src/string.ts
@@ -114,9 +114,9 @@ export function utilUniqueString(val) {
 // regardless of case or diacritics.
 // If supported, will use the browser's language sensitive string comparison, see:
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator
-export function utilSortString(locale: string): (x: string, y: string) => number {
-  if ('Intl' in window && 'Collator' in Intl) {
-      return (new Intl.Collator(locale || 'en', {
+export function utilSortString(locale = 'en'): (x: string, y: string) => number {
+  if (typeof Intl === 'object' && 'Collator' in Intl) {
+      return (new Intl.Collator(locale, {
           sensitivity: 'base',
           numeric: true
       })).compare;

--- a/packages/util/tests/string.test.ts
+++ b/packages/util/tests/string.test.ts
@@ -182,3 +182,18 @@ describe('utilUniqueString', () => {
     expect(util.utilUniqueString('Hello World!')).toMatch(/^ideditor-hello_world_-\d+$/);
   });
 });
+
+describe('utilSortString', function() {
+  var cmp = util.utilSortString('en');
+  it('sorts strings', function() {
+      expect(cmp('a', 'b')).toBeLessThan(0);
+      expect(cmp('b', 'a')).toBeGreaterThan(0);
+      expect(cmp('a', 'a')).toEqual(0);
+  });
+  it('sorts strings case insentitively', function() {
+      expect(cmp('a', 'A')).toEqual(0);
+  });
+  it('sorts strings not regarding diacritics insentitively', function() {
+      expect(cmp('a', 'à')).toEqual(0);
+  });
+});

--- a/packages/util/tests/string.test.ts
+++ b/packages/util/tests/string.test.ts
@@ -184,16 +184,25 @@ describe('utilUniqueString', () => {
 });
 
 describe('utilSortString', function() {
-  var cmp = util.utilSortString('en');
-  it('sorts strings', function() {
+  function testCases(cmp) {
+    it('sorts strings', function() {
       expect(cmp('a', 'b')).toBeLessThan(0);
       expect(cmp('b', 'a')).toBeGreaterThan(0);
       expect(cmp('a', 'a')).toEqual(0);
-  });
-  it('sorts strings case insentitively', function() {
+    });
+    it('sorts strings case insentitively', function() {
       expect(cmp('a', 'A')).toEqual(0);
-  });
-  it('sorts strings not regarding diacritics insentitively', function() {
+    });
+    it('sorts strings not regarding diacritics insentitively', function() {
       expect(cmp('a', 'à')).toEqual(0);
-  });
+    });
+  }
+  testCases(util.utilSortString('en'));
+  testCases(util.utilSortString());
+  const _Intl = Intl;
+  Intl = undefined;
+  testCases(util.utilSortString('en'));
+  Intl = {};
+  testCases(util.utilSortString('en'));
+  Intl = _Intl;
 });


### PR DESCRIPTION
Uses the browser's [`Intl.Collator` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator) if present and falls back to a more simple implementation which "just" removes diacritics and makes the comparison case-insensitive.

originally proposed by @1ec5 in https://github.com/openstreetmap/iD/pull/8826#discussion_r757821753